### PR TITLE
🐛 Fix account name line break on sm screen

### DIFF
--- a/themes/codechilli-slcfhr/layouts/donate/list.html
+++ b/themes/codechilli-slcfhr/layouts/donate/list.html
@@ -47,7 +47,9 @@
               <li
                 class="list-group-item d-flex justify-content-between align-items-center">
                 Account Number
-                <span class="badge badge-light badge-pill text-monospace">
+                <span
+                  class="badge badge-light badge-pill text-monospace"
+                  style="display: block;">
                   {{ site.Params.account_number }}
                 </span>
               </li>


### PR DESCRIPTION
The bank name on the donation page is overflowed on small screens. Fixed it by adding an inlike CSS style.